### PR TITLE
The "go-nasne" may not work in an environment where int size is 32 bits

### DIFF
--- a/nasne/type.go
+++ b/nasne/type.go
@@ -41,9 +41,9 @@ type Audio struct {
 }
 
 type ContainerSize struct {
-	Main   int
-	Mobile int
-	Thumb  int
+	Main   uint64
+	Mobile uint64
+	Thumb  uint64
 }
 
 // Title is response


### PR DESCRIPTION
I got the following error in my QNAP environment.

```
% /path/to/mackerel-plugin-nasne 192.168.xxx.xxx
2018/10/10 01:37:51 OutputValues:  json: cannot unmarshal number 3108463425 into Go struct field ContainerSize.Main of type int
```

This is because 3108463425 exceeds the upper limit of 32 bit int. So, I explicitly specified ContainerSize.Main as uint64.

It may not be necessary for ContainerSize.Mobile and ContainerSize.Thumb to be uint64, but I uniformed it for clarity.